### PR TITLE
Remove the `auto1.route_describers.route_metadata` definition

### DIFF
--- a/DependencyInjection/Auto1ServiceAPIHandlerExtension.php
+++ b/DependencyInjection/Auto1ServiceAPIHandlerExtension.php
@@ -2,6 +2,7 @@
 
 namespace Auto1\ServiceAPIHandlerBundle\DependencyInjection;
 
+use Nelmio\ApiDocBundle\NelmioApiDocBundle;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -24,5 +25,9 @@ class Auto1ServiceAPIHandlerExtension extends Extension
 
         //Load config files
         $loader->load('services.yml');
+
+        if (!class_exists(NelmioApiDocBundle::class)) {
+            $container->removeDefinition('auto1.route_describers.route_metadata');
+        }
     }
 }


### PR DESCRIPTION
The `Auto1\ServiceAPIHandlerBundle\ApiDoc\EndpointRouteDescriber` class [uses classes](https://github.com/auto1-oss/service-api-handler-bundle/blob/master/ApiDoc/EndpointRouteDescriber.php#L12-L16) from the `nelmio/api-doc-bundle` bundle. As this bundle is usually used in the `dev` mode, the definition for this class is also not needed and should be removed.