### PR TITLE
Fix case with _instanceof service definitions

### DIFF
--- a/DependencyInjection/CompilerPass/EndpointRouterCompilerPass.php
+++ b/DependencyInjection/CompilerPass/EndpointRouterCompilerPass.php
@@ -30,6 +30,9 @@ class EndpointRouterCompilerPass implements CompilerPassInterface
         $services = [];
 
         foreach ($container->getDefinitions() as $id => $definition) {
+            if (strpos($id, '.abstract.instanceof.') === 0) {
+                continue;
+            }
             $services[$id] = $definition->getClass();
         }
 


### PR DESCRIPTION
**How to reproduce:**

`class IndexController implements LoggerAwareInterface`
```yaml
services:
    _instanceof:
        Psr\Log\LoggerAwareInterface:
            calls:
                - [setLogger, ['@logger']]
```

> InvalidArgumentException
> Controller ".abstract.instanceof.App\Controller\IndexController" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?

Symfony creates two services pointing to same class, what leads to generation of invalid routes:
```
"App\Controller\IndexController" => "App\Controller\IndexController"
".abstract.instanceof.App\Controller\IndexController" => "App\Controller\IndexController"
```
`".abstract.instanceof.App\Controller\IndexController:getDataAction" => "App\Request\GetDataRequest"`