### PR TITLE
Fix Deprecations for php8.0+

### DIFF
--- a/DependencyInjection/CompilerPass/EndpointRouterCompilerPass.php
+++ b/DependencyInjection/CompilerPass/EndpointRouterCompilerPass.php
@@ -33,7 +33,12 @@ class EndpointRouterCompilerPass implements CompilerPassInterface
             if (strpos($id, '.abstract.instanceof.') === 0) {
                 continue;
             }
-            $services[$id] = $definition->getClass();
+
+            $class = $definition->getClass();
+            if ($class === null) {
+                continue;
+            }
+            $services[$id] = $class;
         }
 
         $classToServiceMapping = array_flip($this->filterControllers($services));
@@ -168,10 +173,6 @@ class EndpointRouterCompilerPass implements CompilerPassInterface
     private function filterControllers(array $classes) : array
     {
         return \array_filter($classes, function ($v) {
-            if ($v === null) {
-                return false;
-            }
-
             return \substr($v, -\strlen(self::CONTROLLER_SUFFIX)) === self::CONTROLLER_SUFFIX;
         });
     }


### PR DESCRIPTION
Fixes the following deprations
```
E_DEPRECATED: Method ReflectionParameter::getClass() is deprecated
E_DEPRECATED: substr(): Passing null to parameter #1 ($string) of type string is deprecated
```