### PR TITLE
PUR2-1718: Adding query parameters to resolver.

### DIFF
--- a/ArgumentResolver/ServiceRequestResolver.php
+++ b/ArgumentResolver/ServiceRequestResolver.php
@@ -91,7 +91,8 @@ class ServiceRequestResolver implements ArgumentValueResolverInterface
                 )
                     : []
                 ,
-                $request->attributes->all()
+                $request->attributes->all(),
+                $request->query->all()
             );
 
             $this->serviceResponseListener->addExpectedRequestEndpoint($request, $endpoint);

--- a/Tests/ArgumentResolver/ServiceRequestResolverTest.php
+++ b/Tests/ArgumentResolver/ServiceRequestResolverTest.php
@@ -152,7 +152,7 @@ class ServiceRequestResolverTest extends TestCase
     public function testResolve(): void
     {
         $generator = $this->serviceRequestResolver->resolve(
-            new Request([], [], ['baz' => 'qux'], [], [], [], 'foobar'),
+            new Request(['asd' => 'dsa'], [], ['baz' => 'qux'], [], [], [], 'foobar'),
             $this->createMetadata()
         );
         $endpointProphecy = $this->prophesize(EndpointInterface::class);
@@ -169,7 +169,7 @@ class ServiceRequestResolverTest extends TestCase
             ->willReturn(['foo' => 'bar'])
             ->shouldBeCalled();
         $this->serializerProphecy->denormalize(
-            ['foo' => 'bar', 'baz' => 'qux'],
+            ['foo' => 'bar', 'baz' => 'qux', 'asd' => 'dsa'],
             RequestStub::class,
             'json',
             Argument::cetera()


### PR DESCRIPTION
https://wkdauto.atlassian.net/browse/PUR2-1718

This PR allows us to create DTOs using query parameters for GET endpoints.

For example, for the given URL:
`GET /v1/vat/vat-partitions/country/ES?localeCode=es-ES`

service-api-endpoints-bundle:
```
endpoints:
  - requestClass:  'WKDA\DTO\VatService\VatService\Request\GetVatPartitionCollectionByCountry'
    method:        'GET'
    path:          '/v1/vat/vat-partitions/country/{country}'
    responseClass: 'WKDA\DTO\VatService\VatService\Response\VatPartitionCollection'
```

DTO:
```
<?php

declare(strict_types=1);

namespace WKDA\DTO\VatService\VatService\Request;

use Auto1\ServiceAPIRequest\ServiceRequestInterface;

/**
 * Class GetVatPartitionCollectionByCountry
 */
class GetVatPartitionCollectionByCountry implements ServiceRequestInterface
{
    /**
     * @var string
     */
    private $country;

    /**
     * @var string|null
     */
    private $localeCode;

    /**
     * @return string
     */
    public function getCountry(): string
    {
        return $this->country;
    }

    /**
     * @param string $country
     * @return $this
     */
    public function setCountry(string $country): self
    {
        $this->country = $country;

        return $this;
    }

    public function getLocaleCode(): ?string
    {
        return $this->localeCode;
    }

    public function setLocaleCode(?string $localeCode): self
    {
        $this->localeCode = $localeCode;

        return $this;
    }
}

```

We can use the `localeCode` parameter from the DTO:
```
    public function getByCountryAction(GetVatPartitionCollectionByCountry $request): JsonResponse
    {
        return new JsonResponse(
            $this->serializer->serialize(
                $this->vatPartitionService->getListByCountry($request->getCountry(), $request->getLocaleCode()),
                'json'
            ),
            Response::HTTP_OK,
            [],
            true
        );
    }
```