### PR TITLE
EVA-3177: strip query string from endpoint path when registering routes (v1.2.x backport)

### DIFF
--- a/Routing/EndpointLoader.php
+++ b/Routing/EndpointLoader.php
@@ -59,7 +59,7 @@ class EndpointLoader extends Loader
 
             //TODO: go through $requestClass and set requirements \d+ etc based on type
             $route = new Route(
-                $endpoint->getPath(),
+                $this->stripQueryString($endpoint->getPath()),
                 ['_controller' => $controller]
             );
             $route->setMethods([$endpoint->getMethod()]);
@@ -76,5 +76,15 @@ class EndpointLoader extends Loader
     public function supports($resource, $type = null)
     {
         return 'endpoint_handler' === $type;
+    }
+
+    /**
+     * Endpoint paths may contain a query string template (e.g. "/v1/cars?ids={ids}") used by API clients
+     * to build request URIs. Routes are matched against the path info only, so the query string must not
+     * be part of the route path.
+     */
+    private function stripQueryString(string $path): string
+    {
+        return explode('?', $path, 2)[0];
     }
 }

--- a/Tests/Routing/EndpointLoaderTest.php
+++ b/Tests/Routing/EndpointLoaderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the auto1-oss/service-api-handler-bundle.
+ *
+ * (c) AUTO1 Group SE https://www.auto1-group.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Auto1\ServiceAPIHandlerBundle\Routing;
+
+use Auto1\ServiceAPIComponentsBundle\Service\Endpoint\EndpointInterface;
+use Auto1\ServiceAPIComponentsBundle\Service\Endpoint\EndpointRegistryInterface;
+use Auto1\ServiceAPIHandlerBundle\Routing\EndpointLoader;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+
+class EndpointLoaderTest extends TestCase
+{
+    private const CONTROLLER = 'App\Controller\SomeController::someAction';
+
+    public function testLoadStripsQueryStringFromRoutePath(): void
+    {
+        $routes = $this->loadRoutes('/v1/items?excludeIds={excludeIds}', 'GET');
+
+        $route = $routes->get(RequestStub::class);
+        $this->assertNotNull($route);
+        $this->assertSame('/v1/items', $route->getPath());
+        $this->assertSame(['GET'], $route->getMethods());
+    }
+
+    public function testLoadKeepsPathPlaceholders(): void
+    {
+        $routes = $this->loadRoutes('/v1/cars/{id}', 'POST');
+
+        $route = $routes->get(RequestStub::class);
+        $this->assertNotNull($route);
+        $this->assertSame('/v1/cars/{id}', $route->getPath());
+        $this->assertSame(['POST'], $route->getMethods());
+    }
+
+    public function testRouteWithQueryStringTemplateMatchesRequestWithoutQueryParams(): void
+    {
+        $routes = $this->loadRoutes('/v1/items?excludeIds={excludeIds}', 'GET');
+
+        $matcher = new UrlMatcher($routes, new RequestContext('', 'GET'));
+        $parameters = $matcher->match('/v1/items');
+
+        $this->assertSame(self::CONTROLLER, $parameters['_controller']);
+        $this->assertSame(RequestStub::class, $parameters['_route']);
+    }
+
+    private function loadRoutes(string $path, string $method): RouteCollection
+    {
+        $endpointProphecy = $this->prophesize(EndpointInterface::class);
+        $endpointProphecy->getPath()->willReturn($path);
+        $endpointProphecy->getMethod()->willReturn($method);
+
+        $endpointRegistryProphecy = $this->prophesize(EndpointRegistryInterface::class);
+        $endpointRegistryProphecy->getEndpoint(Argument::type(RequestStub::class))
+            ->willReturn($endpointProphecy->reveal());
+
+        $endpointLoader = new EndpointLoader(
+            $endpointRegistryProphecy->reveal(),
+            [self::CONTROLLER => RequestStub::class]
+        );
+
+        $routes = $endpointLoader->load('.', 'endpoint_handler');
+        $this->assertInstanceOf(RouteCollection::class, $routes);
+
+        return $routes;
+    }
+}

--- a/Tests/Routing/EndpointLoaderTest.php
+++ b/Tests/Routing/EndpointLoaderTest.php
@@ -13,13 +13,11 @@ declare(strict_types=1);
 
 namespace Tests\Auto1\ServiceAPIHandlerBundle\Routing;
 
-use Auto1\ServiceAPIComponentsBundle\Service\Endpoint\EndpointInterface;
+use Auto1\ServiceAPIComponentsBundle\Service\Endpoint\Endpoint;
 use Auto1\ServiceAPIComponentsBundle\Service\Endpoint\EndpointRegistryInterface;
 use Auto1\ServiceAPIHandlerBundle\Routing\EndpointLoader;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Symfony\Component\Routing\Matcher\UrlMatcher;
-use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 
 class EndpointLoaderTest extends TestCase
@@ -46,26 +44,15 @@ class EndpointLoaderTest extends TestCase
         $this->assertSame(['POST'], $route->getMethods());
     }
 
-    public function testRouteWithQueryStringTemplateMatchesRequestWithoutQueryParams(): void
-    {
-        $routes = $this->loadRoutes('/v1/items?excludeIds={excludeIds}', 'GET');
-
-        $matcher = new UrlMatcher($routes, new RequestContext('', 'GET'));
-        $parameters = $matcher->match('/v1/items');
-
-        $this->assertSame(self::CONTROLLER, $parameters['_controller']);
-        $this->assertSame(RequestStub::class, $parameters['_route']);
-    }
-
     private function loadRoutes(string $path, string $method): RouteCollection
     {
-        $endpointProphecy = $this->prophesize(EndpointInterface::class);
-        $endpointProphecy->getPath()->willReturn($path);
-        $endpointProphecy->getMethod()->willReturn($method);
+        $endpoint = (new Endpoint())
+            ->setPath($path)
+            ->setMethod($method);
 
         $endpointRegistryProphecy = $this->prophesize(EndpointRegistryInterface::class);
         $endpointRegistryProphecy->getEndpoint(Argument::type(RequestStub::class))
-            ->willReturn($endpointProphecy->reveal());
+            ->willReturn($endpoint);
 
         $endpointLoader = new EndpointLoader(
             $endpointRegistryProphecy->reveal(),

--- a/Tests/Routing/RequestStub.php
+++ b/Tests/Routing/RequestStub.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the auto1-oss/service-api-handler-bundle.
+ *
+ * (c) AUTO1 Group SE https://www.auto1-group.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Auto1\ServiceAPIHandlerBundle\Routing;
+
+use Auto1\ServiceAPIRequest\ServiceRequestInterface;
+
+class RequestStub implements ServiceRequestInterface
+{
+}


### PR DESCRIPTION
Backport of EVA-3177 to the `v1.2.x` maintenance line (cherry-pick of ad87acb from `master`/v1.4.0).

Endpoint paths may contain a query string template (e.g. `/v1/cars?ids={ids}`) that API clients use to build request URIs. Symfony matches routes against the path info only, so a route registered with the query string in its path can never match.

Strip everything from `?` onward before creating the route. Request DTO population is unaffected: `ServiceRequestResolver` already reads query parameters from the actual request.

The cherry-pick applied cleanly; the v1.2.x method signatures on `EndpointLoader::load()` / `supports()` are preserved (no `: object` / `: bool` return types from the 1.4 line).
